### PR TITLE
fix: tokens exceeded with too many related memories.

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,8 @@ elif model == 'Claude':
 	user_oauth_token = config['LLM_Claude']['user_oauth_token']
 	bot_id = config['LLM_Claude']['bot_id']
 	brain = Claude(bot_id, user_oauth_token, name)
+ 
+max_tokens = int(config['LLM']['max_tokens'])
 
 waifu = Waifu(brain=brain,
 				prompt=prompt,
@@ -64,7 +66,8 @@ waifu = Waifu(brain=brain,
 				use_emoji=use_emoji,
 				use_qqface=use_qqface,
                 use_emotion=use_emotion,
-				use_emoticon=use_emoticon)
+				use_emoticon=use_emoticon, 
+    			max_tokens=max_tokens)
 
 # 记忆导入
 filename = config['CyberWaifu']['memory']

--- a/template.ini
+++ b/template.ini
@@ -30,6 +30,9 @@ send_voice = True
 # 2. Claude
 model = OpenAI
 
+# 请输入每次允许发送的最大token数量，一般来讲和所选的模型最大token限制一致
+max_tokens = 4096
+
 [LLM_OpenAI]
 openai_key =
 


### PR DESCRIPTION
有的时候会出现单条记忆比较长的情况，这样几条相关记忆加上去，token上限就超出了，导致不能正常发送prompt。加了一个简单的处理，如果检测到当前的几条相关记忆加上去后会超出最大token数限制，那么就按照相似度从低到高删除记忆。