### PR TITLE
修复“pop from empty list”的报错，对话重复和一些诡异的对话输出

### DIFF
--- a/waifu/llm/GPT.py
+++ b/waifu/llm/GPT.py
@@ -28,11 +28,25 @@ class GPT(Brain):
 
 
     def think(self, messages: List[BaseMessage]):
-        return self.llm(messages).content
+        response = self.llm(messages)
+        if response.content:
+            return response.content
+        else:
+            # 简化信息后再发送
+            simplified_messages = messages[:-1] + [BaseMessage(content="Simplified version of the question", role=messages[-1].role)]
+            response = self.llm(simplified_messages)
+            return response.content if response.content else "Sorry, I couldn't generate a response."
 
 
     def think_nonstream(self, messages: List[BaseMessage]):
-        return self.llm_nonstream(messages).content
+        response = self.llm_nonstream(messages)
+        if response.content:
+            return response.content
+        else:
+            # 简化信息后再发送
+            simplified_messages = messages[:-1] + [BaseMessage(content="Simplified version of the question", role=messages[-1].role)]
+            response = self.llm_nonstream(simplified_messages)
+            return response.content if response.content else "Sorry, I couldn't generate a response."
 
 
     def store_memory(self, text: str | list):


### PR DESCRIPTION
通过简化请求来避免“pop from empty list”的错误和适当保留之前信息来避免一些非常诡异的输出和对话重复输出。